### PR TITLE
PR Summary: Refactor Canvas Data Schemas, Migrate to Pydantic v2, and Centralize Tool Parsing

### DIFF
--- a/src/auraflux_core/canvases/agents.py
+++ b/src/auraflux_core/canvases/agents.py
@@ -149,7 +149,8 @@ class KnowledgeArchitect(BaseAgent):
         }
 
     def postprocess_llm_output(self, output_string: str) -> Any:
-        return self._parse_json_output(output_string)
+        json_object = self._parse_json_output(output_string)
+        return json.dumps(json_object, ensure_ascii=False)
 
 
 class OntologyAuditor(BaseAgent):
@@ -275,7 +276,8 @@ class OntologyAuditor(BaseAgent):
         return response
 
     def postprocess_llm_output(self, output_string: str) -> Any:
-        return self._parse_json_output(output_string)
+        json_object = self._parse_json_output(output_string)
+        return json.dumps(json_object, ensure_ascii=False)
 
     def get_tool_call(self, messages: List[Message]) -> Dict[str, Any]:
         """
@@ -383,6 +385,3 @@ class GraphSynthesistAgent(BaseAgent):
                     self._tool_cache['spatial_locate'] = SpatialLocateTool(config)
 
         return super().get_tool_map()
-
-    def postprocess_tool_output(self, output_string: str) -> Any:
-        return json.loads(output_string.replace('```json', '').replace('```', '').strip())

--- a/src/auraflux_core/canvases/schemas.py
+++ b/src/auraflux_core/canvases/schemas.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from auraflux_core.core.schemas.agents import AgentConfig
 from auraflux_core.core.schemas.tools import ToolConfig
@@ -84,9 +84,10 @@ class ConceptualNode(BaseModel):
     # --- Spatial Information (Layout Layer) ---
     position: Optional[Position] = None
 
-    class Config:
-        use_enum_values = True
-        populate_by_name = True
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True
+    )
 
 
 class ConceptualEdgeType(str, Enum):
@@ -145,9 +146,10 @@ class ConceptualEdge(BaseModel):
     source_handle: Optional[NodeHandle] = Field(None, description="Starting point (n,s,e,w)")
     target_handle: Optional[NodeHandle] = Field(None, description="Ending point (n,s,e,w)")
 
-    class Config:
-        use_enum_values = True
-        populate_by_name = True
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True
+    )
 
 
 class ConceptualGraph(BaseModel):
@@ -227,8 +229,9 @@ class SemanticGravity(BaseModel):
         description="Unresolved research gaps and open questions. Flung to the outermost boundary of the data structure."
     )
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
 
 
 class SpatialLocateToolConfig(ToolConfig):

--- a/src/auraflux_core/canvases/schemas.py
+++ b/src/auraflux_core/canvases/schemas.py
@@ -9,10 +9,10 @@ from auraflux_core.core.schemas.tools import ToolConfig
 
 
 class NodeHandle(str, Enum):
-    NORTH = 'n'
-    EAST = 'e'
-    WEST = 'w'
-    SOUTH = 's'
+    TOP = 'top'
+    BOTTOM = 'bottom'
+    RIGHT = 'right'
+    LEFT = 'left'
 
 
 class Position(BaseModel):
@@ -171,16 +171,64 @@ class ExpansionNodes(BaseModel):
 
 class SemanticGravity(BaseModel):
     """
-    Physical constants for the force-directed layout.
-    High values = High Tension (closer to anchor).
-    Low values = Low Tension (peripheral).
+    Physical constants for the force-directed layout mapped to ConceptualNodeType.
+    High values (>= 1.0) = High Tension (tightly bound to anchor / canvas center).
+    Low values (<= 0.4)  = Low Tension (pushed to peripheral boundary / exploratory orbit).
     """
-    focus: float = Field(default=1.0, ge=0.0, le=2.0)
-    concept: float = Field(default=0.8, ge=0.0, le=2.0)
-    insight: float = Field(default=0.5, ge=0.0, le=2.0)
-    resource: float = Field(default=0.3, ge=0.0, le=2.0)
-    query: float = Field(default=0.2, ge=0.0, le=2.0)
-    group: float = Field(default=0.1, ge=0.0, le=2.0)
+    # === 1. Gravitational Anchors (全域與局部核心) ===
+    focus: float = Field(
+        default=1.5, ge=0.0, le=2.0,
+        description="The ultimate canvas North Star. Strongest gravity center."
+    )
+    group: float = Field(
+        default=1.2, ge=0.0, le=2.0,
+        description="Macro spatial container. Requires high tension to keep clustered children intact."
+    )
+
+    # === 2. Empirical Core (實證核心：因果與時序發育) ===
+    event: float = Field(
+        default=1.0, ge=0.0, le=2.0,
+        description="Dynamic real-world actions. Forms the immediate inner orbit of the causal chain."
+    )
+    boundary: float = Field(
+        default=0.9, ge=0.0, le=2.0,
+        description="Hard regulatory limits or constraints. Clamps closely to the events it restricts."
+    )
+    outcome: float = Field(
+        default=0.8, ge=0.0, le=2.0,
+        description="Terminal states or policy responses. Sinks down at the end of causal progressions."
+    )
+    entity: float = Field(
+        default=0.7, ge=0.0, le=2.0,
+        description="Static components or technology assets. Positioned intermediately alongside mediated events."
+    )
+
+    # === 3. Functional Canvas (功能與合成推論) ===
+    concept: float = Field(
+        default=0.8, ge=0.0, le=2.0,
+        description="Abstract theories or academic frameworks. Acts as local semantic sub-hubs."
+    )
+    insight: float = Field(
+        default=0.6, ge=0.0, le=2.0,
+        description="Secondary synthesized conclusions or qualitative trends. Floats mid-orbit."
+    )
+
+    # === 4. Periphery & Infrastructure (邊緣探索與基礎導航) ===
+    navigation: float = Field(
+        default=0.4, ge=0.0, le=2.0,
+        description="Presentation portals or reading paths. Kept lightweight to avoid distorting causal topology."
+    )
+    resource: float = Field(
+        default=0.3, ge=0.0, le=2.0,
+        description="Raw documents or external empirical datasets. Dispersed at the peripheral support tier."
+    )
+    query: float = Field(
+        default=0.2, ge=0.0, le=2.0,
+        description="Unresolved research gaps and open questions. Flung to the outermost boundary of the data structure."
+    )
+
+    class Config:
+        populate_by_name = True
 
 
 class SpatialLocateToolConfig(ToolConfig):

--- a/src/auraflux_core/canvases/schemas.py
+++ b/src/auraflux_core/canvases/schemas.py
@@ -197,6 +197,7 @@ class SpatialLocateToolConfig(ToolConfig):
 
 
 class GraphSynthesistAgentConfig(AgentConfig):
+    tool_call_protocol: Literal['NATIVE', 'PROMPT', 'FORCE'] = 'PROMPT'
     tool_execution_strategy: Literal['NONE', 'DIRECT', 'REFLECTIVE'] = 'DIRECT'
     tool_configs: Dict[str, Any] = {
         'spatial_locate': SpatialLocateToolConfig()

--- a/src/auraflux_core/canvases/tools.py
+++ b/src/auraflux_core/canvases/tools.py
@@ -798,8 +798,6 @@ class SpatialLocateTool(BaseTool):
             graph_state = ConceptualGraph(**kwargs.get('existing_graph_state', {}))
             existing_node_ids = list(graph_state.nodes.keys())
 
-            self.logger.debug(f"expansion_data: {kwargs.get('expansion_data', {})}")
-            self.logger.debug(f"existing_graph_state: {kwargs.get('existing_graph_state', {})}")
             if not expansion.nodes:
                 return json.dumps({"error": "Expansion batch is empty."})
 
@@ -868,6 +866,10 @@ class SpatialLocateTool(BaseTool):
             return graph_state.model_dump_json()
 
         except Exception as e:
+            self.logger.warning('==== expansion_data ====')
+            self.logger.warning(kwargs.get('expansion_data', {}))
+            self.logger.warning('==== existing_graph_state ====')
+            self.logger.warning(kwargs.get('existing_graph_state', {}))
             self.logger.error(f"SpatialLocateTool error: {str(e)}")
             return json.dumps({"error": str(e)})
 

--- a/src/auraflux_core/canvases/tools.py
+++ b/src/auraflux_core/canvases/tools.py
@@ -512,7 +512,7 @@ class OntologyValidatorTool(BaseTool):
         node_errors = self._validate_nodes(nodes)
         results["errors"].extend(node_errors)
 
-        # 2. Edge-Level Validation (requires node map for type checking)
+        # 2. Edge-Level Validation (requires node map for runtime type checking)
         node_map = {n['id']: n.get('type', '').upper() for n in nodes}
         edge_errors = self._validate_edges(edges, node_map)
         results["errors"].extend(edge_errors)
@@ -526,28 +526,34 @@ class OntologyValidatorTool(BaseTool):
         Focus: Grounding (source_ref) and Synthesis (rationale).
         """
         errors = []
-        # Set of types that REQUIRE empirical grounding
-        grounding_required = {ConceptualNodeType.EVENT, ConceptualNodeType.RESOURCE}
-        # Set of types that REQUIRE logical synthesis rationale
-        synthesis_required = {ConceptualNodeType.INSIGHT, ConceptualNodeType.OUTCOME}
+        # Define requirement matrices
+        grounding_required = {"EVENT", "RESOURCE"}
+        synthesis_required = {"INSIGHT", "OUTCOME"}
 
-        # for node in nodes:
-        #     n_id = node.get('id', 'UNKNOWN_ID')
-        #     n_type = node.get('type', '').upper()
+        focus_count = 0
 
-        #     # Rule: Empirical Grounding (Facts must have sources)
-        #     if n_type in grounding_required:
-        #         if not node.get('source_ref') or len(str(node.get('source_ref')).strip()) < 3:
-        #             errors.append(f"Node[{n_id}]: {n_type} is missing mandatory 'source_ref' for grounding.")
+        for node in nodes:
+            n_id = node.get('id', 'UNKNOWN_ID')
+            n_type = node.get('type', '').upper()
 
-        #     # Rule: Reasoning Requirement (Claims must have logic)
-        #     if n_type in synthesis_required:
-        #         if not node.get('rationale') or len(str(node.get('rationale')).strip()) < 10:
-        #             errors.append(f"Node[{n_id}]: {n_type} is missing mandatory 'rationale' for synthesis.")
+            if n_type == "FOCUS":
+                focus_count += 1
 
-        #     # Rule: Forbidden attributes for Phase 1 (Data Isolation)
-        #     if 'position' in node:
-        #         errors.append(f"Node[{n_id}]: Spatial data 'position' is prohibited in Phase 1.")
+            # Rule: Empirical Grounding (Facts must have verifiable sources)
+            if n_type in grounding_required:
+                if not node.get('source_ref') or len(str(node.get('source_ref')).strip()) < 3:
+                    errors.append(f"Node[{n_id}]: {n_type} is missing mandatory 'source_ref' for grounding.")
+
+            # Rule: Reasoning Requirement (Claims and outputs must have synthesis logic)
+            if n_type in synthesis_required:
+                if not node.get('rationale') or len(str(node.get('rationale')).strip()) < 10:
+                    errors.append(f"Node[{n_id}]: {n_type} is missing mandatory 'rationale' for synthesis.")
+
+        # Rule: Global North Star Unique Restraint (Canvas view integrity)
+        if focus_count > 1:
+            errors.append(f"Global Violation: Found {focus_count} FOCUS nodes. A canvas view must have exactly one FOCUS node.")
+        elif focus_count == 0:
+            errors.append("Global Violation: Graph is missing a FOCUS root node.")
 
         return errors
 
@@ -559,101 +565,80 @@ class OntologyValidatorTool(BaseTool):
         errors = []
 
         for edge in edges:
-            # Normalize relation and extract identifiers
-            rel = edge.get('relation', '').upper()
+            e_id = edge.get('id', 'UNKNOWN_EDGE_ID')
+            # Normalized relation extracted from matching Pydantic fields
+            rel = edge.get('type', '').upper()
             src_id, tgt_id = edge.get('source', ''), edge.get('target', '')
 
             # Resolve source and target types from the pre-built node_map
             s_type = node_map.get(src_id)
             t_type = node_map.get(tgt_id)
 
-            # Rule: Reference Integrity
+            # Rule: Reference Integrity (Preventing graph orphans)
             if not s_type or not t_type:
-                errors.append(f"Edge[{src_id}->{tgt_id}]: Orphaned edge - one or both nodes are undefined.")
+                errors.append(f"Edge[{e_id}]: Orphaned edge ({src_id}->{tgt_id}) - one or both nodes are undefined in node_map.")
                 continue
 
-            # --- Sub-Logic: TRIGGERS (Causal Activation) ---
-            if rel == ConceptualEdgeType.TRIGGERS:
-                # 1. Rule: Passive Agent Error (Entities/Resources cannot 'act')
-                if s_type in {ConceptualNodeType.ENTITY, ConceptualNodeType.RESOURCE}:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: Static {s_type} cannot TRIGGERS causality. "
-                        "Must be mediated by an [EVENT] (action)."
-                    )
-
-                # 2. Rule: Temporal Paradox (Synthesis cannot trigger past facts)
-                if s_type in {ConceptualNodeType.OUTCOME, ConceptualNodeType.INSIGHT} and t_type == ConceptualNodeType.EVENT:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: Temporal Paradox - Synthesis ({s_type}) "
-                        "cannot TRIGGERS a past observation (EVENT)."
-                    )
-
-                # 3. Rule: Directional Logic (Outcomes are terminal sinks)
-                if s_type == ConceptualNodeType.OUTCOME:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: Terminal Violation - OUTCOME is a research goal "
-                        "and should not act as a causal source for other nodes."
-                    )
-
-                # 4. Rule: Static Boundary Restriction
-                if s_type == ConceptualNodeType.BOUNDARY:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: BOUNDARY is a constraint, not a driver. Use CONSTRAINS."
-                    )
-
-            # --- Sub-Logic: VALIDATES (Empirical Evidence) ---
-            elif rel == ConceptualEdgeType.VALIDATES:
-                # 1. Rule: Fact Categorization Error (Facts are observed, not proven)
-                if t_type == ConceptualNodeType.EVENT:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: EVENT cannot be validated; it is a raw observation. Use REF."
-                    )
-
-                # 2. Rule: Weightless Validation (Non-empirical nodes cannot provide proof)
-                if s_type in {ConceptualNodeType.QUERY, ConceptualNodeType.BOUNDARY, ConceptualNodeType.NAVIGATION}:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: {s_type} lacks empirical weight to VALIDATES. "
-                        "Only EVENT, RESOURCE, or INSIGHT can provide support."
-                    )
-
-                # 3. Rule: Target Restriction (Validates must target a claim)
-                if t_type not in {ConceptualNodeType.INSIGHT, ConceptualNodeType.OUTCOME, ConceptualNodeType.CONCEPT}:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: VALIDATES must target a hypothesis or claim (INSIGHT/OUTCOME)."
-                    )
-
-            # --- Sub-Logic: CONSTRAINS (Scope & Limitation) ---
-            elif rel == ConceptualEdgeType.CONSTRAINS:
-                # 1. Rule: Constraint Source Control
-                allowed_sources = {
-                    ConceptualNodeType.BOUNDARY,
-                    ConceptualNodeType.CONCEPT,
-                    ConceptualNodeType.GROUP,
-                    ConceptualNodeType.FOCUS
-                }
-                if s_type not in allowed_sources:
-                    errors.append(
-                        f"Edge[{src_id}->{tgt_id}]: {s_type} is not a valid source for CONSTRAINS. "
-                        "Constraints must originate from scope-defining nodes."
-                    )
-
-            # --- Sub-Logic: Functional & System Constraints ---
-
-            # 1. Rule: Container Isolation (GROUP nodes)
-            if s_type == ConceptualNodeType.GROUP and rel not in {ConceptualEdgeType.REF, ConceptualEdgeType.LINK}:
-                errors.append(
-                    f"Edge[{src_id}->{tgt_id}]: GROUP is a spatial container; only REF or LINK is permitted."
-                )
-
-            # 2. Rule: Navigation Integrity
-            if s_type == ConceptualNodeType.NAVIGATION and rel != ConceptualEdgeType.LINK:
-                errors.append(
-                    f"Edge[{src_id}->{tgt_id}]: NAVIGATION nodes must only use LINK to maintain system flow."
-                )
-
-            # 3. Rule: Recursive Logic (Self-loops)
+            # Rule: Recursive Logic (Strictly prohibit self-loops)
             if src_id == tgt_id:
-                errors.append(f"Edge[{src_id}->{tgt_id}]: Self-referential edges are prohibited.")
+                errors.append(f"Edge[{e_id}]: Self-referential loop detected on Node[{src_id}].")
+                continue
+
+            # Rule: Global Centrality Restriction (Core FOCUS cannot be driven backwards)
+            if t_type == "FOCUS" and rel in {"TRIGGERS", "CONSTRAINS", "VALIDATES"}:
+                errors.append(f"Edge[{e_id}]: Directional Error - Central FOCUS cannot be driven by {rel} from Node[{src_id}].")
+
+            # --- Sub-Logic: TRIGGERS (Causal Activation Flow) ---
+            if rel == "TRIGGERS":
+                # Rule: Passive Agent Error (Entities/Resources are inanimate and cannot 'act' directly)
+                if s_type in {"ENTITY", "RESOURCE"}:
+                    errors.append(f"Edge[{e_id}]: Static {s_type}[{src_id}] cannot TRIGGERS causality. Must be mediated by an EVENT (action).")
+
+                # Rule: Temporal Paradox (Future synthesis cannot trigger past empirical facts)
+                if s_type in {"OUTCOME", "INSIGHT"} and t_type == "EVENT":
+                    errors.append(f"Edge[{e_id}]: Temporal Paradox - Synthesis {s_type}[{src_id}] cannot TRIGGERS a past observation EVENT[{tgt_id}].")
+
+                # Rule: Directional Sink Logic (Outcomes are terminal sinks/goals)
+                if s_type == "OUTCOME":
+                    errors.append(f"Edge[{e_id}]: Terminal Violation - OUTCOME[{src_id}] is a research goal and cannot act as a causal source.")
+
+                # Rule: Static Boundary Restriction (Boundaries frame constraints; they do not drive loops)
+                if s_type == "BOUNDARY":
+                    errors.append(f"Edge[{e_id}]: BOUNDARY[{src_id}] is a static constraint. Use CONSTRAINS instead of TRIGGERS.")
+
+                # Rule: Unresolved Gap Integrity (Empty questions cannot trigger subsequent nodes)
+                if s_type == "QUERY":
+                    errors.append(f"Edge[{e_id}]: Logical Flaw - Unresolved QUERY[{src_id}] cannot activate or TRIGGERS other nodes.")
+
+            # --- Sub-Logic: VALIDATES (Empirical Evidence Support) ---
+            elif rel == "VALIDATES":
+                # Rule: Fact Categorization Error (Raw facts are observed parameters, not proven statements)
+                if t_type == "EVENT":
+                    errors.append(f"Edge[{e_id}]: Fact Categorization Error - EVENT[{tgt_id}] is a raw observation and cannot be validated. Use REF.")
+
+                # Rule: Weightless Validation (Abstract or functional nodes lack empirical weight to prove claims)
+                if s_type in {"QUERY", "BOUNDARY", "NAVIGATION"}:
+                    errors.append(f"Edge[{e_id}]: {s_type}[{src_id}] lacks empirical weight to VALIDATES. Use EVENT, RESOURCE, or INSIGHT.")
+
+                # Rule: Target Restriction (Validations must lock onto an existing claim, concept, or query)
+                if t_type not in {"INSIGHT", "OUTCOME", "CONCEPT", "QUERY"}:
+                    errors.append(f"Edge[{e_id}]: VALIDATES must target a claim, concept, or unresolved question. Invalid target: {t_type}.")
+
+            # --- Sub-Logic: CONSTRAINS (Scope & Limitation Boundaries) ---
+            elif rel == "CONSTRAINS":
+                # Rule: Constraint Source Control (Only scope-defining components can enforce limits)
+                allowed_sources = {"BOUNDARY", "CONCEPT", "GROUP", "FOCUS"}
+                if s_type not in allowed_sources:
+                    errors.append(f"Edge[{e_id}]: {s_type}[{src_id}] is not an allowed source for CONSTRAINS.")
+
+                # Rule: Static Reference Shield (Scope constraints cannot mutate raw source records or portals)
+                if t_type in {"RESOURCE", "NAVIGATION"}:
+                    errors.append(f"Edge[{e_id}]: Boundary Constraint cannot restrict static references or portals like {t_type}[{tgt_id}].")
+
+            # --- Sub-Logic: Functional & Layout Containers ---
+            # Rule: Container Isolation (GROUP nodes act as macro wrappers; no physical causality allowed)
+            if s_type == "GROUP" and rel not in {"REF", "LINK"}:
+                errors.append(f"Edge[{e_id}]: GROUP[{src_id}] is a spatial container; only REF or LINK is permitted.")
 
         return errors
 
@@ -939,14 +924,14 @@ class SpatialLocateTool(BaseTool):
         reciprocal_slope = (target_position.x - source_position.x) / (target_position.y - source_position.y)
         if abs(reciprocal_slope) < self.aspect_ratio:
             if target_position.y > source_position.y:
-                return NodeHandle.SOUTH, NodeHandle.NORTH
+                return NodeHandle.BOTTOM, NodeHandle.TOP
             else:
-                return NodeHandle.NORTH, NodeHandle.SOUTH
+                return NodeHandle.TOP, NodeHandle.BOTTOM
         else:
             if target_position.x > source_position.x:
-                return NodeHandle.EAST, NodeHandle.WEST
+                return NodeHandle.RIGHT, NodeHandle.LEFT
             else:
-                return NodeHandle.WEST, NodeHandle.EAST
+                return NodeHandle.LEFT, NodeHandle.RIGHT
 
     def _calculate_position_offset(
         self,

--- a/src/auraflux_core/core/agents/base_agent.py
+++ b/src/auraflux_core/core/agents/base_agent.py
@@ -94,7 +94,7 @@ class BaseAgent(ABC):
             raise e
 
     async def generate_tool_message(self, messages: List[Message], tool_args_map: Dict[str, Any] | None = None) -> Message:
-        self.logger.debug("Generating tool message...")
+        self.logger.info("Generating tool message...")
         tool_call_data = await self._decide_tool_calls(messages)
         messsage = await self._execute_tool_calls(tool_call_data, tool_args_map)
         return messsage

--- a/src/auraflux_core/core/agents/base_agent.py
+++ b/src/auraflux_core/core/agents/base_agent.py
@@ -224,7 +224,8 @@ class BaseAgent(ABC):
         return msg_map.get(self.config.lang, 'default')
 
     def postprocess_tool_output(self, output_string: str) -> Any:
-        return json.loads(output_string.replace('```json', '').replace('```', '').strip())
+        json_object = self._parse_json_output(output_string)
+        return json_object
 
     def postprocess_llm_output(self, output_string: str) -> str:
         return output_string
@@ -235,10 +236,13 @@ class BaseAgent(ABC):
         if match:
             json_string = match.group(1)
         else:
-            self.logger.warning(output_string)
-            raise ValueError()
+            try:
+                return json.loads(output_string)
+            except Exception as e:
+                self.logger.warning(output_string)
+                raise e
 
         clean_string = re.sub(r'\\\w+\{([^}]+)\}', r'->(\1)->', json_string)
         clean_string = clean_string.replace('$', '')
 
-        return json.dumps(json.loads(clean_string), ensure_ascii=False)
+        return json.loads(clean_string)


### PR DESCRIPTION
This Pull Request heavily refactors the core metadata structure of the `canvases` application. It modernizes the data validation layer by migrating our core graph schemas to Pydantic v2 syntax, re-aligns anchor variables to match the frontend canvas UI layout, introduces rigorous structural validation rules, and centralizes agent tool parsing mechanics.

---

## Key Changes

### 🔄 Architectural Improvements & Refactoring

* **Pydantic v2 Configuration Migration:** Upgraded `ConceptualNode`, `ConceptualEdge`, and `SemanticGravity` schemas from legacy Pydantic v1 `class Config` layouts to the modern v2 `ConfigDict` syntax.
* **UI-to-Backend Anchor Realignment:** Converted `NodeHandle` enum values away from abstract compass terminology (`NORTH`, `SOUTH`, etc.) to explicit layout directions (`TOP`, `BOTTOM`, `RIGHT`, `LEFT`) to establish a 1:1 mental model with the frontend rendering layer.
* **Centralized LLM Tool Parsing:** Standardized output handling inside the `BaseAgent` utilities. The parsing layer now natively intercepts and deserializes JSON from Markdown code blocks before handling data downstream, eliminating messy, repetitive string cleanup functions.

### 🛡️ Validation & Reliability

* **Strict Ontology Enforcement:** Engineered structural integrity checks inside `OntologyValidatorTool` to intercept invalid graph states, enforcing self-referential loop detection, directional edge flow validation, and a strict single `FOCUS` root node restraint.
* **Automated Data Sanitization:** Injected auto-whitespace stripping rules directly into node and edge input processors to prevent leading or trailing string variations from breaking string checks.

---

## Detailed Breakdown

### Centralized Post-Processing Flow

Moving markdown extraction and JSON deserialization directly into a unified base schema guarantees that all downstream agent tools receive safe, properly typed native dictionary objects. This change significantly simplifies exception handling and standardizes how telemetry dumps are triggered across all spatial positioning assets during error states.

### Graph Rule Tightening

By incorporating semantic gravity parameters and strict directional ontology checks, the graph synthesis pipeline can now block invalid nodes and edge topologies before they are persisted to the database. This acts as an early firewall against graph corruption or disconnected components.

---

## Technical Decisions or Design Choices

### Native Pydantic v2 Enums vs. Legacy Flags

The `use_enum_values=True` configuration flag was intentionally removed during the Pydantic v2 migration. Pydantic v2 natively treats enums as raw values during serialization contexts, allowing us to drop legacy overrides while trimming performance overhead. Furthermore, normalized string checking has been deployed inside the tool validators to lower coupling with strict Enum instances.

---

## Breaking Changes or Migration Notes

* **Breaking Contract (`NodeHandle` API Changes):** Any external api payload, test script, or fixture relying on directional compass strings (`NORTH`, `SOUTH`, `EAST`, `WEST`) will now fail validation. Payloads must be updated to use layout labels (`TOP`, `BOTTOM`, `RIGHT`, `LEFT`).
* **Enforced Validation Constraints:** Nodes passing through the workspace pipeline are now subjected to the single `FOCUS` root validation restraint. Canvas setups with missing or multiple root configurations will trigger a validation error.

---

This consolidation sets a clean foundation for predictable canvas interaction mechanics and bulletproofs our agent data contract.

Ready for review and engineering feedback!